### PR TITLE
Fixing internal call of get_sample_cn_segments in examples

### DIFF
--- a/R/subset_cnstates.R
+++ b/R/subset_cnstates.R
@@ -13,8 +13,8 @@
 #' @noRd
 #'
 #' @examples
-#' cn_states = get_sample_cn_segments(these_sample_ids = c("00-15201_tumorA",
-#'                                                         "HTMCP-01-06-00422-01A-01D"),
+#' cn_states = get_sample_cn_segments(these_sample_ids = c("02-13135T",
+#'                                                         "SU-DHL-4"),
 #'                                    streamlined = FALSE)
 #'
 #' subset_cnstates(cn_segments = cn_states,

--- a/R/subset_cnstates.R
+++ b/R/subset_cnstates.R
@@ -13,9 +13,8 @@
 #' @noRd
 #'
 #' @examples
-#' cn_states = get_sample_cn_segments(multiple_samples = TRUE,
-#'                                    sample_list = c("00-15201_tumorA",
-#'                                                    "HTMCP-01-06-00422-01A-01D"),
+#' cn_states = get_sample_cn_segments(these_sample_ids = c("00-15201_tumorA",
+#'                                                         "HTMCP-01-06-00422-01A-01D"),
 #'                                    streamlined = FALSE)
 #'
 #' subset_cnstates(cn_segments = cn_states,


### PR DESCRIPTION
This tiny PR fixes an issue with the examples in `subset_cnstates` that calls `get_sample_cn_segments` with old parameters. This has been resolved in this PR. The issue was revealed during beta testing of the new GAMBLR structure.