### PR TITLE
default font in theme morons

### DIFF
--- a/R/theme_Morons.R
+++ b/R/theme_Morons.R
@@ -24,7 +24,7 @@
 #' theme_Morons()
 #'
 theme_Morons = function(base_size = 14,
-                        base_family = "Arial",
+                        base_family = "Helvetica",
                         my_legend_position = "bottom",
                         my_legend_direction = "horizontal"){
 

--- a/man/theme_Morons.Rd
+++ b/man/theme_Morons.Rd
@@ -6,7 +6,7 @@
 \usage{
 theme_Morons(
   base_size = 14,
-  base_family = "Arial",
+  base_family = "Helvetica",
   my_legend_position = "bottom",
   my_legend_direction = "horizontal"
 )


### PR DESCRIPTION
The default has been changed from arial to helvetica because non-cairo R exports have hard time processing arial font. This resolves #54 

Before:
![image](https://github.com/user-attachments/assets/56aeec65-29fe-49fc-bbe1-e5926addd950)


After:
![image](https://github.com/user-attachments/assets/9588ac2c-ebb0-4a14-b351-93c1e7ebcc58)
