### PR TITLE
add promethION seq_type colour

### DIFF
--- a/R/get_gambl_colours.R
+++ b/R/get_gambl_colours.R
@@ -83,7 +83,8 @@ get_gambl_colours <- function(classification = "all",
   all_colours[["seq_type"]] <- c(
     "mrna" = "#E41A1C",
     "genome" = "#377EB8",
-    "capture" = "#4DAF4A"
+    "capture" = "#4DAF4A",
+    "promethION" = "#f78b3e"
   )
 
   all_colours[["type"]] <- c(


### PR DESCRIPTION
## Describe your changes

Very simple PR, just adding promethION seq_type to get_gambl_colours(). I chose a light orange so as to not conflict with the other seq_type colours.

## Indicate which issue(s) this addresses, if applicable

## Checklist before requesting a review
- [ ] I tested the new function/functionality in a fresh workspace
- [ ] I added at least one working example that demonstrates the new functionality (*if applicable*)
- [ ] The test script tools/logExampleOutputs.R ran to completion
- [ ] I included the file `GAMBLR_examples_output.log` in my pull request and confirm the changes to this file are expected
